### PR TITLE
Changing Macro Structure to Include User Modifiable Configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
 # EMTFPtAssign2017
 EMTF code for pT LUT training (2017)
+Test commit of JTR fork

--- a/macros/ReadMVAOut.C
+++ b/macros/ReadMVAOut.C
@@ -10,15 +10,18 @@
 #include "TChain.h"
 #include "TTree.h"
 #include "TBranch.h"
+#include "ReadMVAOut.h"
 
 void ReadMVAOut() {
 
+  std::cout<<"foo = "<<foo<<endl;
   // Initialize empty file to access each file in the list
   TFile *file_tmp(0);
 
   // List of input files
   std::vector<TString> in_file_names;
-  in_file_names.push_back("/afs/cern.ch/user/a/abrinke1/TMVA/EMTFPtAssign2017/PtRegression_AWB_v0_16_12_09.root");
+  //in_file_names.push_back("/afs/cern.ch/user/a/abrinke1/TMVA/EMTFPtAssign2017/PtRegression_AWB_v0_16_12_09.root");
+  in_file_names.push_back(str_file_location);
 
   // Open all input files
   for (UInt_t i = 0; i < in_file_names.size(); i++) {

--- a/macros/ReadMVAOut.h
+++ b/macros/ReadMVAOut.h
@@ -1,0 +1,6 @@
+//****************************************************************************************************************
+// ReadMVAOut.C Configuration
+// -Change the value of "str_file_location" to the full path of the file you wish to access
+//**************************************************************************************************************** 
+
+string str_file_location = "/storage1/users/jtr6/EMTF_ML_training_results/PtRegression_v0_MLP.root"; 

--- a/macros/configs/ReadMVAOut_AWB.h
+++ b/macros/configs/ReadMVAOut_AWB.h
@@ -1,0 +1,6 @@
+//****************************************************************************************************************
+// ReadMVAOut.C Configuration
+// -Change the value of "str_file_location" to the full path of the file you wish to access
+//**************************************************************************************************************** 
+
+string str_file_location = "/afs/cern.ch/user/a/abrinke1/TMVA/EMTFPtAssign2017/PtRegression_AWB_v0_16_12_09.root"; 

--- a/macros/configs/ReadMVAOut_JTR.h
+++ b/macros/configs/ReadMVAOut_JTR.h
@@ -1,0 +1,6 @@
+//****************************************************************************************************************
+// ReadMVAOut.C Configuration
+// -Change the value of "str_file_location" to the full path of the file you wish to access
+//**************************************************************************************************************** 
+
+string str_file_location = "/storage1/users/jtr6/EMTF_ML_training_results/PtRegression_v0_MLP.root"; 

--- a/macros/configs/ReadMe.txt
+++ b/macros/configs/ReadMe.txt
@@ -1,0 +1,1 @@
+Store and edit your config files here with your initials appended to the end.  


### PR DESCRIPTION
A test of changing using a config-based structure for setting parameters. This should facilitate collaboration by allowing users to set parameters for their own studies/environments without altering the macros (and eventually regressors) themselves. If this works well, it can be expanded upon. 